### PR TITLE
NormalizedRGBColor (represent RGB color as single value)

### DIFF
--- a/scripts/headers/Common/Color/NormalizedRGBColor.h
+++ b/scripts/headers/Common/Color/NormalizedRGBColor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "Common/Color/RGBColor.h"
+
+procedure rgb_normalize_ints(variable red_int, variable green_int, variable blue_int) begin
+    // TODO - see if Star-Trek Scripting Language has bitwise shifting? https://stackoverflow.com/a/16697893
+    //        meanwhile just combining 3x 3-digit ints into a string
+    return string_left_pad(("" + red_int),   3, "0") +
+           string_left_pad(("" + green_int), 3, "0") +
+           string_left_pad(("" + blue_int),  3, "0");
+end
+
+procedure rgb_normalize_floats(variable red_float, variable green_float, variable blue_float) begin
+    return rgb_normalize_ints(
+        rgb_float_to_int(red_float),
+        rgb_float_to_int(green_float),
+        rgb_float_to_int(blue_float)
+    );
+end
+
+procedure rgb_normalize_hex(variable hex_string) begin
+    hex_string = rgb_hex_string(hex_string);
+    if hex_string then
+        return rgb_normalize_ints(
+            HexToDecimal(substr(hex_string, 0, 2)),
+            HexToDecimal(substr(hex_string, 2, 2)),
+            HexToDecimal(substr(hex_string, 4, 2))
+        );
+    else
+        return "000000000";
+end
+
+#define rgb_extract_red_int(combined_rgb)   (round(atof(substr(combined_rgb, 0, 3))))
+#define rgb_extract_green_int(combined_rgb) (round(atof(substr(combined_rgb, 3, 3))))
+#define rgb_extract_blue_int(combined_rgb)  (round(atof(substr(combined_rgb, 6, 3))))
+
+#define rgb_extract_red_float(combined_rgb)   rgb_int_to_float(rgb_extract_red_int(combined_rgb))
+#define rgb_extract_green_float(combined_rgb) rgb_int_to_float(rgb_extract_green_int(combined_rgb))
+#define rgb_extract_blue_float(combined_rgb)  rgb_int_to_float(rgb_extract_blue_int(combined_rgb))
+
+#define rgb_normalized_to_hex(combined_rgb) \
+    ( \
+        string_left_pad(DecimalToHex(rgb_extract_red_int(combined_rgb)),   2, "0") + \
+        string_left_pad(DecimalToHex(rgb_extract_green_int(combined_rgb)), 2, "0") + \
+        string_left_pad(DecimalToHex(rgb_extract_blue_int(combined_rgb)),  2, "0") \
+    )

--- a/scripts/headers/Common/Color/RGBColor.h
+++ b/scripts/headers/Common/Color/RGBColor.h
@@ -64,10 +64,6 @@ procedure rgb_blue_int_from_hex(variable hex_string) begin
         return 0;
 end
 
-#define rgb_red_from_hex(hex_string)   rgb_red_float_from_hex(hex_string)
-#define rgb_green_from_hex(hex_string) rgb_green_float_from_hex(hex_string)
-#define rgb_blue_from_hex(hex_string)  rgb_blue_float_from_hex(hex_string)
-
 procedure rgb_red_float_from_hex(variable hex_string) begin
     variable int_value = rgb_red_int_from_hex(hex_string);
     if int_value then
@@ -91,45 +87,3 @@ procedure rgb_blue_float_from_hex(variable hex_string) begin
     else
         return 0.0;
 end
-
-procedure rgb_normalize_ints(variable red_int, variable green_int, variable blue_int) begin
-    // TODO - see if Star-Trek Scripting Language has bitwise shifting? https://stackoverflow.com/a/16697893
-    //        meanwhile just combining 3x 3-digit ints into a string
-    return string_left_pad(("" + red_int),   3, "0") +
-           string_left_pad(("" + green_int), 3, "0") +
-           string_left_pad(("" + blue_int),  3, "0");
-end
-
-procedure rgb_normalize_floats(variable red_float, variable green_float, variable blue_float) begin
-    return rgb_normalize_ints(
-        rgb_float_to_int(red_float),
-        rgb_float_to_int(green_float),
-        rgb_float_to_int(blue_float)
-    );
-end
-
-procedure rgb_normalize_hex(variable hex_string) begin
-    hex_string = rgb_hex_string(hex_string);
-    if hex_string then
-        return rgb_normalize_ints(
-            HexToDecimal(substr(hex_string, 0, 2)),
-            HexToDecimal(substr(hex_string, 2, 2)),
-            HexToDecimal(substr(hex_string, 4, 2))
-        );
-    else
-        return "000000000";
-end
-
-#define rgb_extract_red_int(combined_rgb)   (atoi(substr(combined_rgb, 0, 3)))
-#define rgb_extract_green_int(combined_rgb) (atoi(substr(combined_rgb, 3, 3)))
-#define rgb_extract_blue_int(combined_rgb)  (atoi(substr(combined_rgb, 6, 3)))
-
-#define rgb_extract_red(combined_rgb)   rgb_extract_red_float(combined_rgb)
-#define rgb_extract_green(combined_rgb) rgb_extract_green_float(combined_rgb)
-#define rgb_extract_blue(combined_rgb)  rgb_extract_blue_float(combined_rgb)
-
-#define rgb_extract_red_float(combined_rgb)   rgb_int_to_float(rgb_extract_red_int(combined_rgb))
-#define rgb_extract_green_float(combined_rgb) rgb_int_to_float(rgb_extract_green_int(combined_rgb))
-#define rgb_extract_blue_float(combined_rgb)  rgb_int_to_float(rgb_extract_blue_int(combined_rgb))
-
-// #define rgb_normalized_to_hex(normalized) "TODO"

--- a/tests/Color/gl_CommonLib_NormalizedRGBColor_Test.ssl
+++ b/tests/Color/gl_CommonLib_NormalizedRGBColor_Test.ssl
@@ -1,0 +1,44 @@
+#include "Waterchip.h"
+#include "Common/Color/NormalizedRGBColor.h"
+
+describe("NormalizedRGBColor") begin
+
+    variable normalized;
+
+    it("can normalize RGB hex into a single value and extract float RGB pieces") begin
+        normalized = rgb_normalize_hex("abcdef");
+        expect(rgb_extract_red_float(normalized))   to_equal(171.0 / 255); // ab=171
+        expect(rgb_extract_green_float(normalized)) to_equal(205.0 / 255); // cd=205
+        expect(rgb_extract_blue_float(normalized))  to_equal(239.0 / 255); // ef=239
+    end
+
+    it("can normalize RGB floats into a single value and extract float RGB pieces") begin
+        normalized = rgb_normalize_floats(
+            rgb_red_float_from_hex("abcdef"),
+            rgb_green_float_from_hex("abcdef"),
+            rgb_blue_float_from_hex("abcdef")
+        );
+        expect(rgb_extract_red_float(normalized))   to_equal(171.0 / 255); // ab=171
+        expect(rgb_extract_green_float(normalized)) to_equal(205.0 / 255); // cd=205
+        expect(rgb_extract_blue_float(normalized))  to_equal(239.0 / 255); // ef=239
+    end
+
+    it("can normalize RGB integers into a single value and extract float RGB pieces") begin
+        normalized = rgb_normalize_ints(
+            rgb_red_int_from_hex("abcdef"),
+            rgb_green_int_from_hex("abcdef"),
+            rgb_blue_int_from_hex("abcdef")
+        );
+        expect(rgb_extract_red_float(normalized))   to_equal(171.0 / 255); // ab=171
+        expect(rgb_extract_green_float(normalized)) to_equal(205.0 / 255); // cd=205
+        expect(rgb_extract_blue_float(normalized))  to_equal(239.0 / 255); // ef=239
+    end
+
+    it("can convert normalized RBG value into HTML hex color string") begin
+        expect(rgb_normalized_to_hex(rgb_normalize_ints(0,   0,   0)))   to_equal("000000"); 
+        expect(rgb_normalized_to_hex(rgb_normalize_ints(1,   15,  255))) to_equal("010FFF"); 
+        expect(rgb_normalized_to_hex(rgb_normalize_ints(0,   123, 0)))   to_equal("007B00"); 
+        expect(rgb_normalized_to_hex(rgb_normalize_ints(255, 255, 255))) to_equal("FFFFFF"); 
+    end
+end
+

--- a/tests/Color/gl_CommonLib_RGBColor_Test.ssl
+++ b/tests/Color/gl_CommonLib_RGBColor_Test.ssl
@@ -4,9 +4,6 @@
 #define hex(hex_string) HexToDecimal(hex_string)
 
 describe("RGBColor") begin
-
-    variable normalized;
-
     it("can get full-length 6-character HTML color hex string given triplets") begin
         // For 6, return what we're provided
         expect(rgb_hex_string("abcdef")) to_equal("abcdef");
@@ -67,34 +64,16 @@ describe("RGBColor") begin
     end
 
     it("can get RGB float values of RGB from hex color") begin
-        expect(rgb_red_from_hex("00ffff"))   to_equal(0.0);
-        expect(rgb_green_from_hex("ff00ff")) to_equal(0.0);
-        expect(rgb_blue_from_hex("ffff00"))  to_equal(0.0);
+        expect(rgb_red_float_from_hex("00ffff"))   to_equal(0.0);
+        expect(rgb_green_float_from_hex("ff00ff")) to_equal(0.0);
+        expect(rgb_blue_float_from_hex("ffff00"))  to_equal(0.0);
 
-        expect(rgb_red_from_hex("ff0000"))   to_equal(1.0);
-        expect(rgb_green_from_hex("00ff00")) to_equal(1.0);
-        expect(rgb_blue_from_hex("0000ff"))  to_equal(1.0);
+        expect(rgb_red_float_from_hex("ff0000"))   to_equal(1.0);
+        expect(rgb_green_float_from_hex("00ff00")) to_equal(1.0);
+        expect(rgb_blue_float_from_hex("0000ff"))  to_equal(1.0);
 
-        expect(rgb_red_from_hex("abcdef"))   to_equal(171.0 / 255); // ab=171
-        expect(rgb_green_from_hex("abcdef")) to_equal(205.0 / 255); // cd=205
-        expect(rgb_blue_from_hex("abcdef"))  to_equal(239.0 / 255); // ef=239
-    end
-
-    it("can normalize RGB hex into a single float and extract RGB pieces") begin
-        normalized = rgb_normalize_hex("abcdef");
-        expect(rgb_extract_red(normalized))   to_equal(171.0 / 255); // ab=171
-        expect(rgb_extract_green(normalized)) to_equal(205.0 / 255); // cd=205
-        expect(rgb_extract_blue(normalized))  to_equal(239.0 / 255); // ef=239
-    end
-
-    it("can normalize RGB floats into a single float and extract RGB pieces") begin
-        normalized = rgb_normalize_floats(
-            rgb_red_from_hex("abcdef"),
-            rgb_green_from_hex("abcdef"),
-            rgb_blue_from_hex("abcdef")
-        );
-        expect(rgb_extract_red(normalized))   to_equal(171.0 / 255); // ab=171
-        expect(rgb_extract_green(normalized)) to_equal(205.0 / 255); // cd=205
-        expect(rgb_extract_blue(normalized))  to_equal(239.0 / 255); // ef=239
+        expect(rgb_red_float_from_hex("abcdef"))   to_equal(171.0 / 255); // ab=171
+        expect(rgb_green_float_from_hex("abcdef")) to_equal(205.0 / 255); // cd=205
+        expect(rgb_blue_float_from_hex("abcdef"))  to_equal(239.0 / 255); // ef=239
     end
 end


### PR DESCRIPTION
Stored as string concatenated, 0-left-padded integers, e.g. "000255000"

Because this is much cheaper than storing as hex and doing hex to decimal conversions.

Extracting one part requires atoi(substr())

More specifically, we use round(atof(substr())) due to atoi not supporting 0-left-padded integer strings