### PR TITLE
Return webcolor_hex without '#' (specifically, return using rgb_hex_s…

### DIFF
--- a/scripts/headers/Common/Color/WebColors.h
+++ b/scripts/headers/Common/Color/WebColors.h
@@ -2,6 +2,7 @@
 
 #include "sfall/sfall.h"
 #include "sfall/lib.strings.h"
+#include "Common/Color/RGBColor.h"
 
 #define WEBCOLORS_INI_PATH "mods/CommonLib/Color/WebColors.ini"
 
@@ -10,5 +11,5 @@ procedure webcolor_hex(variable color_name) begin
         WEBCOLORS_INI_PATH + "|colors|" + 
         string_replace(string_tolower(color_name), " ", "")
     );
-    return color_hex if color_hex != "" else 0;
+    return rgb_hex_string(color_hex) if color_hex != "" else 0;
 end

--- a/tests/Color/gl_CommonLib_WebColors_Test.ssl
+++ b/tests/Color/gl_CommonLib_WebColors_Test.ssl
@@ -5,21 +5,21 @@ describe("WebColors") begin
     it("can get the hexcode for a HTML color name") begin
         expect(webcolor_hex("does not exist")) to_equal(0);
 
-        expect(webcolor_hex("black")) to_equal("#000000");
-        expect(webcolor_hex("white")) to_equal("#FFFFFF");
+        expect(webcolor_hex("black")) to_equal("000000");
+        expect(webcolor_hex("white")) to_equal("FFFFFF");
 
-        expect(webcolor_hex("Black")) to_equal("#000000");
-        expect(webcolor_hex("White")) to_equal("#FFFFFF");
+        expect(webcolor_hex("Black")) to_equal("000000");
+        expect(webcolor_hex("White")) to_equal("FFFFFF");
 
-        expect(webcolor_hex("BLACK")) to_equal("#000000");
-        expect(webcolor_hex("WHITE")) to_equal("#FFFFFF");
+        expect(webcolor_hex("BLACK")) to_equal("000000");
+        expect(webcolor_hex("WHITE")) to_equal("FFFFFF");
 
-        expect(webcolor_hex("deeppink")) to_equal("#FF1493");
-        expect(webcolor_hex("fuchsia")) to_equal("#FF00FF");
-        expect(webcolor_hex("magenta")) to_equal("#FF00FF");
-        expect(webcolor_hex("mediumvioletred")) to_equal("#C71585");
+        expect(webcolor_hex("deeppink")) to_equal("FF1493");
+        expect(webcolor_hex("fuchsia")) to_equal("FF00FF");
+        expect(webcolor_hex("magenta")) to_equal("FF00FF");
+        expect(webcolor_hex("mediumvioletred")) to_equal("C71585");
 
-        expect(webcolor_hex("deep pink")) to_equal("#FF1493");
-        expect(webcolor_hex("medium violetred")) to_equal("#C71585");
+        expect(webcolor_hex("deep pink")) to_equal("FF1493");
+        expect(webcolor_hex("medium violetred")) to_equal("C71585");
     end
 end


### PR DESCRIPTION
…tring)